### PR TITLE
Do not re-download assets if they are already present

### DIFF
--- a/wgpu-mc-demo/build.rs
+++ b/wgpu-mc-demo/build.rs
@@ -10,20 +10,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut paths_to_copy = Vec::new();
     paths_to_copy.push("../res/");
     fs_extra::copy_items(&paths_to_copy, out_dir, &copy_options)?;
+    let resources_root: std::path::PathBuf = "../res/assets".into();
+    if !resources_root.is_dir() {
+        let path = std::path::PathBuf::from("/tmp/mc-jar-cache");
 
-    let path = std::path::PathBuf::from("/tmp/mc-jar-cache");
+        if !path.is_dir() {
+            std::fs::create_dir("/tmp/mc-jar-cache")?;
+        }
 
-    if !path.is_dir() {
-        std::fs::create_dir("/tmp/mc-jar-cache")?;
+        let response = reqwest::blocking::get("https://launcher.mojang.com/v1/objects/37fd3c903861eeff3bc24b71eed48f828b5269c8/client.jar").unwrap();
+        let content = io::Cursor::new(response.bytes()?);
+        let mut zip = zip::read::ZipArchive::new(content)?;
+        zip.extract(&path)?;
+        fs_extra::dir::copy(path.join("assets"), "../res/", &copy_options)?;
+
+        std::fs::remove_dir_all(path)?;
     }
-
-    let response = reqwest::blocking::get("https://launcher.mojang.com/v1/objects/37fd3c903861eeff3bc24b71eed48f828b5269c8/client.jar").unwrap();
-    let content = io::Cursor::new(response.bytes()?);
-    let mut zip = zip::read::ZipArchive::new(content)?;
-    zip.extract(&path)?;
-    fs_extra::dir::copy(path.join("assets"), "../res/", &copy_options)?;
-
-    std::fs::remove_dir_all(path)?;
 
     Ok(())
 }


### PR DESCRIPTION
Previously `build.rs` would redownload the minecraft jar on every build, even if nothing has changed, slowing down IDEs to a crawl.